### PR TITLE
Validate missing methods between local and remote

### DIFF
--- a/lib/mix/tasks/slack_api_docs.gen.json.ex
+++ b/lib/mix/tasks/slack_api_docs.gen.json.ex
@@ -30,8 +30,6 @@ defmodule Mix.Tasks.SlackApiDocs.Gen.Json do
     output_path = List.first(args) || @default_output_path
     concurrency = opts[:concurrency]
 
-    IO.inspect(args)
-
     original_shell = Mix.shell()
     if opts[:quiet], do: Mix.shell(Mix.Shell.Quiet)
 


### PR DESCRIPTION
## Description

When running `mix slack_api_docs.verify <path>` we now also verify whether the local files have **ALL** currently active Web API methods. Before verify would only validate the existing local files vs their remote counter part.

![image](https://user-images.githubusercontent.com/1291263/183408298-a54d88bf-b897-4e0e-96f4-67016eaa36c5.png)

### How to validate?

- Run `mix slack_api_docs.gen.json tmp/slack/web/docs`
- Rename some of the files in the `tmp/slack/web/docs` directory (e.g. `admin.apps.restrict2.json`)
- Run `mix slack_api_docs.verify tmp/slack/web/docs`
- It should error out
