### PR TITLE
bugfix: make sure dependencies are installed

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -24,9 +24,9 @@ defmodule SlackAPIDocs.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:floki, "~> 0.33.0", only: [:dev, :test], runtime: false},
-      {:httpoison, "~> 1.8", only: [:dev, :test], runtime: false},
-      {:jason, "~> 1.3", only: [:dev, :test], runtime: false},
+      {:floki, "~> 0.33.0"},
+      {:httpoison, "~> 1.8"},
+      {:jason, "~> 1.3"},
       {:ex_doc, "~> 0.14", only: :dev, runtime: false}
     ]
   end


### PR DESCRIPTION
## Description

Fixes a bug where if you install the package, the dependencies are not installed, meaning the mix task does not work.