### PR TITLE
Fix bug where example blocks sometimes contain default value

### DIFF
--- a/lib/mix/slack_api_docs/method_page.ex
+++ b/lib/mix/slack_api_docs/method_page.ex
@@ -15,7 +15,8 @@ defmodule Mix.SlackApiDocs.MethodPage do
     argument_name: ".apiMethodPage__argument",
     argument_description: ".apiMethodPage__argumentDesc p",
     argument_type: ".apiMethodPage__argumentType",
-    argument_example: ".apiReference__exampleCode",
+    argument_example: ".apiReference__example",
+    argument_example_code: ".apiReference__exampleCode",
 
     # Example responses
     example_responses: ".apiReference__response .apiReference__example pre",
@@ -104,11 +105,25 @@ defmodule Mix.SlackApiDocs.MethodPage do
       %ApiDocArgument{
         name: Floki.find(argument, @elements.argument_name) |> Floki.text(),
         desc: Floki.find(argument, @elements.argument_description) |> Floki.text(),
-        example: Floki.find(argument, @elements.argument_example) |> Floki.text(),
+        example: parse_example(argument),
         type: type,
         required: is_required
       }
     end)
+  end
+
+  defp parse_example(wrapper) do
+    Floki.find(wrapper, @elements.argument_example)
+    |> Enum.filter(fn el ->
+      # Find the argument "example" that is actually an example.
+      # Slack also shows the "Default" value in the example block sometimes.
+      "example" == Floki.find(el, "strong") |> Floki.text() |> String.downcase()
+    end)
+    |> Enum.map(fn el ->
+      Floki.find(el, @elements.argument_example_code)
+      |> Floki.text()
+    end)
+    |> Enum.join(",")
   end
 
   defp mark_as_conditionally_required(arguments) do

--- a/test/integration/methods_test.exs
+++ b/test/integration/methods_test.exs
@@ -115,6 +115,31 @@ defmodule Test.Integration.MethodTest do
     end
   end
 
+  describe "chat.unfurl" do
+    test "should return correct %ApiDoc{}" do
+      assert api_doc =
+               %ApiDoc{} =
+               MethodPage.gather!(%{
+                 "name" => "chat.unfurl",
+                 "description" => "Provide custom unfurl behavior for user-posted URLs",
+                 "isDeprecated" => false,
+                 "link" => "/methods/chat.unfurl"
+               })
+
+      # Arguments with both "default" and "example"
+      assert %ApiDocArgument{
+               name: "user_auth_required",
+               required: false,
+               example: user_auth_required_example,
+               type: "boolean",
+               desc: user_auth_required_desc
+             } = api_doc.args["user_auth_required"]
+
+      assert "true" == user_auth_required_example
+      assert "" != user_auth_required_desc
+    end
+  end
+
   defp assert_all_in_list(expected_list, given_list) do
     assert Enum.all?(expected_list, fn value -> Enum.member?(given_list, value) end),
            """


### PR DESCRIPTION
## Description

Slack sometimes puts their `default` value within their example block as well. This fixes that and makes sure that if we ever have multiple examples, we parse them correctly.

### Example

![image](https://user-images.githubusercontent.com/1291263/183706753-84e604cf-9ebf-4253-9ed3-c4a0cbbc4cff.png)

### Before

```jsonc
{
  "user_auth_required": {
    // ...
    "example": "0true",
    // ...
  },
}
```

### This PR

```jsonc
{
  "user_auth_required": {
    // ...
    "example": "true",
    // ...
  },
}
```